### PR TITLE
Allow Granola::Rack#json to receive an existing response argument.

### DIFF
--- a/lib/granola/rack.rb
+++ b/lib/granola/rack.rb
@@ -34,10 +34,8 @@ module Granola::Rack
   # Raises NameError if no specific serializer is provided and we fail to infer
   #   one for this object.
   # Returns a Rack response tuple.
-  def json(object, with: nil, status: 200, response: nil, **json_options)
+  def json(object, with: nil, status: 200, response: Rack::Response.new, **json_options)
     serializer = serializer_for(object, with: with)
-    response ||= Rack::Response.new
-    response.status = status
 
     if serializer.last_modified
       response["Last-Modified".freeze] = serializer.last_modified.httpdate

--- a/lib/granola/rack.rb
+++ b/lib/granola/rack.rb
@@ -1,5 +1,6 @@
 require "digest/md5"
 require "time"
+require "rack"
 require "granola"
 require "granola/helper"
 require "granola/caching"
@@ -33,32 +34,34 @@ module Granola::Rack
   # Raises NameError if no specific serializer is provided and we fail to infer
   #   one for this object.
   # Returns a Rack response tuple.
-  def json(object, with: nil, status: 200, **json_options)
+  def json(object, with: nil, status: 200, response: nil, **json_options)
     serializer = serializer_for(object, with: with)
-    headers = {}
+    response ||= Rack::Response.new
+    response.status = status
 
     if serializer.last_modified
-      headers["Last-Modified".freeze] = serializer.last_modified.httpdate
+      response["Last-Modified".freeze] = serializer.last_modified.httpdate
     end
 
     if serializer.cache_key
-      headers["ETag".freeze] = Digest::MD5.hexdigest(serializer.cache_key)
+      response["ETag".freeze] = Digest::MD5.hexdigest(serializer.cache_key)
     end
 
     stale_check = StaleCheck.new(
       env,
-      last_modified: headers["Last-Modified".freeze],
-      etag: headers["ETag".freeze]
+      last_modified: response["Last-Modified".freeze],
+      etag: response["ETag".freeze]
     )
 
     if stale_check.fresh?
-      [304, headers, []]
+      response.status = 304
     else
       json_string = serializer.to_json(json_options)
-      headers["Content-Type".freeze] = serializer.mime_type
-      headers["Content-Length".freeze] = json_string.length.to_s
-      [status, headers, [json_string]]
+      response["Content-Type".freeze] = serializer.mime_type
+      response["Content-Length".freeze] = json_string.length.to_s
+      response.write json_string
     end
+    response.finish
   end
 
   # Internal: Check whether a request is fresh or stale by both modified time

--- a/test/rack_test.rb
+++ b/test/rack_test.rb
@@ -29,12 +29,12 @@ end
 
 test "adds the JSON body to the response" do |context|
   response = context.json(@person)
-  assert_equal [%q({"name":"John Doe","age":25})], response[2]
+  assert_equal [%q({"name":"John Doe","age":25})], response[2].body
 end
 
 test "adds the JSON body of an empty list to the response" do |context|
   response = context.json([])
-  assert_equal ["[]"], response[2]
+  assert_equal ["[]"], response[2].body
 end
 
 test "sets the Content-Type and Content-Length on the response" do |context|
@@ -51,6 +51,13 @@ test "sets the Last-Modified and ETag headers" do |context|
 
   expected_last_modified = Time.at(987654321).httpdate
   assert_equal expected_last_modified, response[1]["Last-Modified"]
+end
+
+test "preserve response headers" do |context|
+  res = Rack::Response.new
+  res["Other-Header"] = "meow"
+  response = context.json(@person, response: res)
+  assert_equal response[1]["Other-Header"], "meow"
 end
 
 setup do
@@ -73,3 +80,4 @@ test "doesn't set Content-* for a fresh response" do |context|
   assert response[1]["Content-Type"].nil?
   assert response[1]["Content-Length"].nil?
 end
+


### PR DESCRIPTION
Sometimes its necessary to send some extra header along with the json response (X-RateLimit-Limit: 5000, X-RateLimit-Remaining: 4999, X-Total-Pages: 23).