### PR TITLE
Correct MessagePack usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ class BaseSerializer < Granola::Serializer
   MIME_TYPES[:msgpack] = "application/x-msgpack".freeze
 
   def to_msgpack(*)
-    MsgPack.pack(data)
+    MessagePack.pack(data)
   end
 end
 ```


### PR DESCRIPTION
`msgpack` gem exposes `MessagePack` module.

This fixes possible test issues when attempt to take README
example into real-world(tm) situations :smile: 

MessagePack documentation:

https://github.com/msgpack/msgpack-ruby#serializing-objects

Thank you

:heart: :heart: :heart: 