### PR TITLE
RFC: Granola::Serializer#to_serializer

### DIFF
--- a/lib/granola/rendering.rb
+++ b/lib/granola/rendering.rb
@@ -36,7 +36,7 @@ module Granola
   def self.render(type, via:, content_type:)
     RENDERERS[type.to_sym] = Renderer.new(via, content_type)
     Serializer.send :define_method, "to_#{type}" do |**opts, &block|
-      Granola.renderer(type).render(self, **opts, &block)
+      Granola.renderer(type).render(to_serializer, **opts, &block)
     end
   end
 

--- a/lib/granola/serializer.rb
+++ b/lib/granola/serializer.rb
@@ -50,6 +50,17 @@ module Granola
     # Returns a Time or `nil`, indicating that no Last-Modified should be sent.
     def last_modified
     end
+
+    # Public: Returns the serializer in the final form before rendering. By
+    # default just returns `self`. This can be used as an extension point to
+    # wrap a serializer with root keys, such as a top-level "results" or adding
+    # like pagination-related information or other meta-information to
+    # serialized objects.
+    #
+    # Returns a Granola::Serializer.
+    def to_serializer
+      self
+    end
   end
 
   # Internal: The List serializer provides an interface for serializing lists of

--- a/test/root_test.rb
+++ b/test/root_test.rb
@@ -1,0 +1,78 @@
+class BaseSerializer < Granola::Serializer
+  def to_serializer
+    RootSerializer.new(self)
+  end
+end
+
+class RootSerializer < Granola::Serializer
+  def data
+    { "results" => object.data }.update(meta)
+  end
+  
+  def meta
+    object.respond_to?(:meta) ? { "meta" => object.meta } : {}
+  end
+end
+
+class UserSerializer < BaseSerializer
+  def data
+    {
+      id: object.id,
+      email: object.email,
+      projects: ProjectSerializer.list(object.projects).data,
+    }
+  end
+
+  def meta
+    {
+      "_self" => "https://example.com/api/users/#{object.id}",
+    }
+  end
+end
+
+class ProjectSerializer < BaseSerializer
+  def data
+    {
+      id: object.id,
+      name: object.name,
+    }
+  end
+
+  def meta
+    {
+      "_self" => "https://example.com/api/projects/#{object.id}",
+    }
+  end
+end
+
+User = Struct.new(:id, :email, :projects)
+Project = Struct.new(:id, :name)
+
+scope do
+  setup do
+    User.new(1, "jane@example.com", [
+      Project.new(1, "First Project"),
+      Project.new(2, "Second Project"),
+    ])
+  end
+
+  test "wraps object to include root keys" do |object|
+    serializer = UserSerializer.new(object)
+
+    expected = {
+      "results" => {
+        "id" => 1,
+        "email" => "jane@example.com",
+        "projects" => [
+          { "id" => 1, "name" => "First Project" },
+          { "id" => 2, "name" => "Second Project" },
+        ],
+      },
+      "meta" => {
+        "_self" => "https://example.com/api/users/1",
+      },
+    }
+
+    assert_equal JSON.dump(expected), serializer.to_json
+  end
+end


### PR DESCRIPTION
The idea here is to simplify including "root keys" in serialized objects. Right now, the simplest way of achieving this is by overwriting `to_json` and similar methods on the serializers to include an object that returns the root keys.

This is a bit messy (or at least repetitive, if you have multiple response formats / renderers in your app.)

In order to simplify this, we can add a `Serializer#to_serializer` method that the renderers use instead of hard-coding `self`. This allows users to implement the concept of a "Root" serializer that wraps the top-level serializer used in every response by simply overriding the `#to_serializer` method in a base serializer used throughout the app.

cc @sd

👍  /  👎?